### PR TITLE
docs: added the Webiny integration details

### DIFF
--- a/config.json
+++ b/config.json
@@ -472,6 +472,42 @@
 	  "type": "Remote Schema"
 	},
 	{
+		"name": "Webiny",
+		"logo_url": "https://raw.githubusercontent.com/swapnilmmane/webiny-logo/main/webiny.svg",
+		"short_desc": " Webiny is Open-Source Serverless Enterprise CMS.",
+		"url_path": "webiny-graphql-api",
+		"github_repo": {
+		  "name": "hasura/data-hub",
+		  "branch": "main",
+		  "readme_repo_path": "/remote-schemas/webiny/README.md"
+		},
+		"developed_by": "Webiny",
+		"released_on": "February 08, 2022",
+		"last_updated": "February 10, 2022",
+		"additional_resources": [
+		  {
+			"text": "Webiny GraphQL API Docs",
+			"link": "https://www.webiny.com/docs/key-topics/webiny-applications/headless-cms/graphql-api"
+		  }
+		],
+		"additional_images": [
+		  {
+			"url": "",
+			"alt": ""
+		  }
+		],
+		"video_demo": null,
+		"integration_link": "https://github.com/hasura/data-hub/tree/main/remote-schemas/webiny",
+		"categories": [
+		  {
+			"name": "CMS"
+		  }
+		],
+		"is_featured": false,
+		"coming_soon": false,
+		"type": "Remote Schema"
+	},
+	{
 	  "name": "Views: Group By & Aggregate",
 	  "logo_url": "https://hasura.github.io/template-gallery/postgres/views-group-aggregate/preview.svg",
 	  "short_desc": "Views can be used to expose the results of a custom query as a virtual table. This example demonstrates grouping by a column and aggregating.",

--- a/remote-schemas/webiny/README.md
+++ b/remote-schemas/webiny/README.md
@@ -1,0 +1,28 @@
+[Webiny](https://www.webiny.com/) is Open-Source Serverless Enterprise CMS. It Includes a Headless CMS, Page Builder, Form Builder, and File Manager.
+
+## Adding Webiny as Remote Schema
+
+- Get the Webiny GraphQL API Endpoint:  
+
+You can visit the API Playground from your Webiny Admin Area application:  
+```
+https://<your-admin-area-url>/api-playground
+```
+Here you will see the Main API, Headless CMS - Manage/Read/Preview API GraphQL URL.  
+Copy the GraphQL URL that you would like to access from Hasura.
+
+- Get the API Key
+You will need this Key to access the GraphQL API. Please follow this [document](https://www.webiny.com/docs/how-to-guides/webiny-applications/headless-cms/using-graphql-api/#creating-the-api-key) to create the API Key.
+
+- Now go to the Hasura Project Console, head to Remote Schemas and enter GraphQL Server URL with the above GraphQL endpoint.   
+
+Select the 'Forward all headers from client' option   
+
+Under Additional Headers,   
+Enter the header name as `Authorization` and in `value` use the following:
+
+```
+Authorization: Bearer <your-Webiny-API-key>
+```
+
+- All set, now Press the `Add Remote Schema` button to add the remote schema, that's it!

--- a/remote-schemas/webiny/README.md
+++ b/remote-schemas/webiny/README.md
@@ -14,7 +14,7 @@
 - Get the API Key
 You will need this Key to access the GraphQL API. Please follow this [document](https://www.webiny.com/docs/how-to-guides/webiny-applications/headless-cms/using-graphql-api/#creating-the-api-key) to create the API Key.
 
-- Now go to the Hasura Project Console, head to Remote Schemas and enter GraphQL Server URL with the above GraphQL endpoint.
+- Now go to the Hasura Project Console, head to Remote Schemas, and enter the GraphQL Server URL you copied from the API Playground.
 
   Select the 'Forward all headers from client' option
 

--- a/remote-schemas/webiny/README.md
+++ b/remote-schemas/webiny/README.md
@@ -2,27 +2,27 @@
 
 ## Adding Webiny as Remote Schema
 
-- Get the Webiny GraphQL API Endpoint:  
+- Get the Webiny GraphQL API Endpoint:
 
-You can visit the API Playground from your Webiny Admin Area application:  
-```
-https://<your-admin-area-url>/api-playground
-```
-Here you will see the Main API, Headless CMS - Manage/Read/Preview API GraphQL URL.  
-Copy the GraphQL URL that you would like to access from Hasura.
+  You can visit the API Playground from your Webiny Admin Area application:
+  ```
+  https://<your-admin-area-url>/api-playground
+  ```
+  Here you will see the Main API, Headless CMS - Manage/Read/Preview API GraphQL URL.  
+  Copy the GraphQL URL that you would like to access from Hasura.
 
 - Get the API Key
 You will need this Key to access the GraphQL API. Please follow this [document](https://www.webiny.com/docs/how-to-guides/webiny-applications/headless-cms/using-graphql-api/#creating-the-api-key) to create the API Key.
 
-- Now go to the Hasura Project Console, head to Remote Schemas and enter GraphQL Server URL with the above GraphQL endpoint.   
+- Now go to the Hasura Project Console, head to Remote Schemas and enter GraphQL Server URL with the above GraphQL endpoint.
 
-Select the 'Forward all headers from client' option   
+  Select the 'Forward all headers from client' option
 
-Under Additional Headers,   
-Enter the header name as `Authorization` and in `value` use the following:
+  Under Additional Headers,  
+  Enter the header name as `Authorization` and in `value` use the following:
 
-```
-Authorization: Bearer <your-Webiny-API-key>
-```
+  ```
+  Authorization: Bearer <your-Webiny-API-key>
+  ```
 
 - All set, now Press the `Add Remote Schema` button to add the remote schema, that's it!


### PR DESCRIPTION
[Webiny](https://www.webiny.com/) is Open-Source Serverless Enterprise CMS.  
Its GraphQL APIs can be accessed using remote schemas in Hasura. 
Added the instructions on how to access the APIs using the Remote Schemas feature.